### PR TITLE
fix: rename latitude and longitude fields to lat and lon in GeoData c…

### DIFF
--- a/product-common/src/main/java/com/zwap/product_common/vo/GeoData.java
+++ b/product-common/src/main/java/com/zwap/product_common/vo/GeoData.java
@@ -11,7 +11,7 @@ import lombok.*;
 @NoArgsConstructor(force = true)
 public class GeoData {
     @NotNull(message = "latitude cannot be null")
-    private double latitude;
+    private double lat;
     @NotNull(message = "longitude cannot be null")
-    private double longitude;
+    private double lon;
 }


### PR DESCRIPTION
"geoData": { "lat": 40.7638, "lon": -73.9721 }